### PR TITLE
Implement GCP-backed recipe management web app

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,99 @@
+import os
+from typing import Optional
+
+from flask import Flask, flash, redirect, render_template, request, url_for
+
+from .models import Recipe
+from .storage import RecipeRepository
+
+try:
+    from .gcp_storage import FirestoreRecipeStorage
+except ImportError:  # pragma: no cover - allows running tests without optional deps
+    FirestoreRecipeStorage = None  # type: ignore[assignment]
+
+ALLOWED_IMAGE_EXTENSIONS = {"png", "jpg", "jpeg", "gif", "webp"}
+
+
+def create_app(storage: Optional[RecipeRepository] = None) -> Flask:
+    """Create and configure the Flask application.
+
+    Parameters
+    ----------
+    storage:
+        Optional recipe repository. When ``None`` the application will use
+        :class:`FirestoreRecipeStorage` configured through environment variables.
+    """
+
+    app = Flask(__name__)
+    app.config.setdefault("MAX_CONTENT_LENGTH", 16 * 1024 * 1024)
+    app.secret_key = os.environ.get("FLASK_SECRET_KEY", "development-secret-change-me")
+
+    if storage is None:
+        if FirestoreRecipeStorage is None:
+            raise RuntimeError(
+                "google-cloud-firestore is not installed. Install optional dependencies "
+                "or pass an explicit storage backend to create_app."
+            )
+        storage = FirestoreRecipeStorage.from_env()
+    app.config["RECIPE_STORAGE"] = storage
+
+    @app.get("/")
+    def index() -> str:
+        recipes = list(app.config["RECIPE_STORAGE"].list_recipes())
+        return render_template("index.html", recipes=recipes, title="Recipe Library")
+
+    @app.post("/recipes")
+    def create_recipe() -> str:
+        storage_backend: RecipeRepository = app.config["RECIPE_STORAGE"]
+
+        title = request.form.get("title", "").strip()
+        description = request.form.get("description", "").strip()
+        ingredients_text = request.form.get("ingredients", "").strip()
+        instructions = request.form.get("instructions", "").strip()
+        image = request.files.get("image")
+
+        if not title:
+            flash("Please provide a recipe title.", "error")
+            return redirect(url_for("index"))
+
+        if image and not _allowed_image(image.filename):
+            flash("Unsupported image format. Allowed formats: PNG, JPG, JPEG, GIF, WEBP.", "error")
+            return redirect(url_for("index"))
+
+        try:
+            storage_backend.add_recipe(
+                title=title,
+                description=description,
+                ingredients_text=ingredients_text,
+                instructions=instructions,
+                image=image,
+            )
+        except Exception as exc:  # pragma: no cover - defensive programming
+            flash(f"Failed to save recipe: {exc}", "error")
+        else:
+            flash(f"Recipe '{title}' saved.", "success")
+
+        return redirect(url_for("index"))
+
+    @app.post("/recipes/<recipe_id>/delete")
+    def delete_recipe(recipe_id: str) -> str:
+        storage_backend: RecipeRepository = app.config["RECIPE_STORAGE"]
+        try:
+            storage_backend.delete_recipe(recipe_id)
+        except Exception as exc:  # pragma: no cover - defensive programming
+            flash(f"Failed to delete recipe: {exc}", "error")
+        else:
+            flash("Recipe deleted.", "success")
+        return redirect(url_for("index"))
+
+    return app
+
+
+def _allowed_image(filename: str) -> bool:
+    if not filename or "." not in filename:
+        return False
+    ext = filename.rsplit(".", 1)[1].lower()
+    return ext in ALLOWED_IMAGE_EXTENSIONS
+
+
+__all__ = ["create_app", "Recipe"]

--- a/app/gcp_storage.py
+++ b/app/gcp_storage.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime
+from typing import Iterable, List, Optional
+
+from google.api_core import exceptions as gcloud_exceptions
+from google.cloud import firestore, storage
+from werkzeug.datastructures import FileStorage
+from werkzeug.utils import secure_filename
+
+from .models import Recipe
+from .storage import RecipeRepository
+
+
+def _parse_ingredients(ingredients_text: str) -> List[str]:
+    return [line.strip() for line in ingredients_text.splitlines() if line.strip()]
+
+
+class FirestoreRecipeStorage(RecipeRepository):
+    """GCP backed recipe storage using Firestore and Cloud Storage."""
+
+    def __init__(
+        self,
+        *,
+        project: Optional[str] = None,
+        collection_name: str = "recipes",
+        bucket_name: Optional[str] = None,
+    ) -> None:
+        self._project = project
+        self._collection_name = collection_name
+        self._bucket_name = bucket_name
+
+        self._firestore_client = firestore.Client(project=project)
+        self._collection = self._firestore_client.collection(collection_name)
+
+        if bucket_name:
+            self._storage_client = storage.Client(project=project)
+            self._bucket = self._storage_client.bucket(bucket_name)
+        else:
+            self._storage_client = None
+            self._bucket = None
+
+    @classmethod
+    def from_env(cls) -> "FirestoreRecipeStorage":
+        """Build a storage instance from environment variables."""
+
+        project = os.environ.get("GCP_PROJECT")
+        collection_name = os.environ.get("RECIPES_COLLECTION", "recipes")
+        bucket_name = os.environ.get("GCS_BUCKET")
+        return cls(project=project, collection_name=collection_name, bucket_name=bucket_name)
+
+    def list_recipes(self) -> Iterable[Recipe]:
+        query = self._collection.order_by("created_at", direction=firestore.Query.DESCENDING)
+        docs = query.stream()
+        for doc in docs:
+            data = doc.to_dict() or {}
+            yield self._doc_to_recipe(doc.id, data)
+
+    def add_recipe(
+        self,
+        *,
+        title: str,
+        description: str,
+        ingredients_text: str,
+        instructions: str,
+        image: FileStorage | None,
+    ) -> Recipe:
+        ingredients = _parse_ingredients(ingredients_text)
+
+        image_url: Optional[str] = None
+        blob_name: Optional[str] = None
+
+        if image and image.filename:
+            if not self._bucket:
+                raise RuntimeError("A Cloud Storage bucket must be configured to upload images.")
+
+            blob_name = self._build_blob_name(image.filename)
+            blob = self._bucket.blob(blob_name)
+
+            image.stream.seek(0)
+            blob.upload_from_file(image.stream, content_type=image.mimetype)
+
+            # Make the file publicly readable so it can be displayed on the website.
+            blob.make_public()
+            image_url = blob.public_url
+
+        doc = {
+            "title": title,
+            "description": description,
+            "ingredients": ingredients,
+            "instructions": instructions,
+            "image_url": image_url,
+            "image_blob_name": blob_name,
+            "created_at": firestore.SERVER_TIMESTAMP,
+        }
+
+        doc_ref = self._collection.document()
+        doc_ref.set(doc)
+
+        snapshot = doc_ref.get()
+        data = snapshot.to_dict() or {}
+        return self._doc_to_recipe(snapshot.id, data)
+
+    def delete_recipe(self, recipe_id: str) -> None:
+        doc_ref = self._collection.document(recipe_id)
+        snapshot = doc_ref.get()
+
+        if not snapshot.exists:
+            raise KeyError(f"Recipe '{recipe_id}' does not exist.")
+
+        data = snapshot.to_dict() or {}
+        blob_name = data.get("image_blob_name")
+
+        if blob_name and self._bucket:
+            blob = self._bucket.blob(blob_name)
+            try:
+                blob.delete()
+            except gcloud_exceptions.NotFound:
+                # The blob may already have been removed manually; ignore.
+                pass
+
+        doc_ref.delete()
+
+    def _doc_to_recipe(self, doc_id: str, data: dict) -> Recipe:
+        ingredients = data.get("ingredients")
+        if isinstance(ingredients, str):
+            parsed_ingredients = _parse_ingredients(ingredients)
+        elif isinstance(ingredients, list):
+            parsed_ingredients = ingredients
+        else:
+            parsed_ingredients = []
+
+        created_at = data.get("created_at")
+        if isinstance(created_at, datetime):
+            timestamp = created_at
+        else:
+            timestamp = None
+
+        return Recipe(
+            id=doc_id,
+            title=data.get("title", ""),
+            description=data.get("description", ""),
+            ingredients=parsed_ingredients,
+            instructions=data.get("instructions", ""),
+            image_url=data.get("image_url"),
+            created_at=timestamp,
+        )
+
+    def _build_blob_name(self, filename: str) -> str:
+        safe = secure_filename(filename)
+        unique = uuid.uuid4().hex
+        return f"recipes/{unique}_{safe}"
+
+
+__all__ = ["FirestoreRecipeStorage"]

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List, Optional
+
+
+@dataclass
+class Recipe:
+    """Domain object representing a stored recipe."""
+
+    id: str
+    title: str
+    description: str
+    ingredients: List[str]
+    instructions: str
+    image_url: Optional[str] = None
+    created_at: Optional[datetime] = None
+
+
+__all__ = ["Recipe"]

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,0 +1,210 @@
+:root {
+  --bg: #f8fafc;
+  --card-bg: #ffffff;
+  --accent: #2563eb;
+  --accent-dark: #1d4ed8;
+  --danger: #dc2626;
+  --danger-dark: #b91c1c;
+  --text: #0f172a;
+  --muted: #475569;
+  --border: #cbd5f5;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body {
+  margin: 0;
+  background-color: var(--bg);
+  color: var(--text);
+}
+
+.container {
+  width: min(960px, 92%);
+  margin: 0 auto;
+}
+
+.app-header {
+  background: linear-gradient(135deg, #1d4ed8, #60a5fa);
+  color: white;
+  padding: 3rem 0 2rem;
+  box-shadow: 0 6px 20px rgba(37, 99, 235, 0.35);
+}
+
+.app-header h1 {
+  margin: 0 0 0.5rem;
+  font-size: 2.5rem;
+}
+
+.app-header .tagline {
+  margin: 0;
+  max-width: 32rem;
+  line-height: 1.5;
+}
+
+main {
+  padding: 2rem 0 4rem;
+}
+
+.app-footer {
+  background: var(--card-bg);
+  padding: 1.5rem 0;
+  border-top: 1px solid var(--border);
+  text-align: center;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.form-section,
+.recipes-section {
+  background: var(--card-bg);
+  border-radius: 16px;
+  padding: 2rem;
+  margin-bottom: 2rem;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+}
+
+.form-section h2,
+.recipes-section h2 {
+  margin-top: 0;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.25rem;
+  margin-bottom: 1.5rem;
+}
+
+label span {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}
+
+input[type='text'],
+textarea,
+input[type='file'] {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  font-size: 1rem;
+  box-sizing: border-box;
+  font-family: inherit;
+}
+
+textarea {
+  resize: vertical;
+  min-height: 120px;
+}
+
+button {
+  cursor: pointer;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+button.primary {
+  background: var(--accent);
+  color: white;
+}
+
+button.primary:hover {
+  background: var(--accent-dark);
+}
+
+button.danger {
+  background: var(--danger);
+  color: white;
+}
+
+button.danger:hover {
+  background: var(--danger-dark);
+}
+
+.recipes-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.recipe-card {
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  overflow: hidden;
+  background: var(--card-bg);
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.06);
+}
+
+.recipe-card img {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+}
+
+.recipe-content {
+  padding: 1.25rem 1.5rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.recipe-content h3 {
+  margin: 0;
+}
+
+.recipe-content .description {
+  color: var(--muted);
+  margin: 0;
+}
+
+.recipe-content ul {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
+.recipe-content ul li + li {
+  margin-top: 0.35rem;
+}
+
+.recipe-content form {
+  margin-top: auto;
+}
+
+.flash-container {
+  margin-bottom: 1.5rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.flash-message {
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  font-weight: 600;
+}
+
+.flash-message.success {
+  background: rgba(34, 197, 94, 0.15);
+  color: #166534;
+}
+
+.flash-message.error {
+  background: rgba(239, 68, 68, 0.15);
+  color: #b91c1c;
+}
+
+.empty-state {
+  color: var(--muted);
+  font-style: italic;
+}
+
+@media (max-width: 640px) {
+  .form-section,
+  .recipes-section {
+    padding: 1.5rem;
+  }
+}

--- a/app/storage.py
+++ b/app/storage.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Iterable, Protocol
+
+from werkzeug.datastructures import FileStorage
+
+from .models import Recipe
+
+
+class RecipeRepository(Protocol):
+    """Protocol describing the behaviour required by the web layer."""
+
+    def list_recipes(self) -> Iterable[Recipe]:
+        """Return an iterable of stored recipes ordered newest first."""
+
+    def add_recipe(
+        self,
+        *,
+        title: str,
+        description: str,
+        ingredients_text: str,
+        instructions: str,
+        image: FileStorage | None,
+    ) -> Recipe:
+        """Persist a new recipe and return the stored instance."""
+
+    def delete_recipe(self, recipe_id: str) -> None:
+        """Remove a recipe and any associated assets."""
+
+
+__all__ = ["RecipeRepository"]

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{ title or "Recipe Library" }}</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="container">
+        <h1>Recipe Library</h1>
+        <p class="tagline">Collect, share, and savour your favourite dishes.</p>
+      </div>
+    </header>
+    <main class="container">
+      {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+      <div class="flash-container">
+        {% for category, message in messages %}
+        <div class="flash-message {{ category }}">{{ message }}</div>
+        {% endfor %}
+      </div>
+      {% endif %}
+      {% endwith %}
+      {% block content %}{% endblock %}
+    </main>
+    <footer class="app-footer">
+      <div class="container">
+        <p>Powered by Google Cloud Firestore and Cloud Storage.</p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,78 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="form-section">
+  <h2>Add a new recipe</h2>
+  <form action="{{ url_for('create_recipe') }}" method="post" enctype="multipart/form-data">
+    <div class="form-grid">
+      <label>
+        <span>Recipe title *</span>
+        <input type="text" name="title" placeholder="Grandma's apple pie" required />
+      </label>
+      <label>
+        <span>Short description</span>
+        <input type="text" name="description" placeholder="Why this recipe is special" />
+      </label>
+      <label class="full-width">
+        <span>Ingredients (one per line)</span>
+        <textarea
+          name="ingredients"
+          rows="4"
+          placeholder="2 cups flour&#10;1 tsp cinnamon"
+        ></textarea>
+      </label>
+      <label class="full-width">
+        <span>Instructions</span>
+        <textarea
+          name="instructions"
+          rows="6"
+          placeholder="Describe how to make the recipe"
+        ></textarea>
+      </label>
+      <label>
+        <span>Optional image</span>
+        <input type="file" name="image" accept="image/png,image/jpeg,image/gif,image/webp" />
+      </label>
+    </div>
+    <button type="submit" class="primary">Save recipe</button>
+  </form>
+</section>
+
+<section class="recipes-section">
+  <h2>Saved recipes</h2>
+  {% if recipes %}
+  <div class="recipes-grid">
+    {% for recipe in recipes %}
+    <article class="recipe-card">
+      {% if recipe.image_url %}
+      <img src="{{ recipe.image_url }}" alt="{{ recipe.title }}" />
+      {% endif %}
+      <div class="recipe-content">
+        <h3>{{ recipe.title }}</h3>
+        {% if recipe.description %}
+        <p class="description">{{ recipe.description }}</p>
+        {% endif %}
+        {% if recipe.ingredients %}
+        <h4>Ingredients</h4>
+        <ul>
+          {% for ingredient in recipe.ingredients %}
+          <li>{{ ingredient }}</li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+        {% if recipe.instructions %}
+        <h4>Instructions</h4>
+        <p class="instructions">{{ recipe.instructions }}</p>
+        {% endif %}
+        <form action="{{ url_for('delete_recipe', recipe_id=recipe.id) }}" method="post">
+          <button type="submit" class="danger">Delete</button>
+        </form>
+      </div>
+    </article>
+    {% endfor %}
+  </div>
+  {% else %}
+  <p class="empty-state">No recipes saved yet. Start by adding one above.</p>
+  {% endif %}
+</section>
+{% endblock %}

--- a/main.py
+++ b/main.py
@@ -1,0 +1,7 @@
+from app import create_app
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8080, debug=False)

--- a/readme.txt
+++ b/readme.txt
@@ -1,1 +1,80 @@
-this project aims to create a recepie management system hosted on Google Cloud Platform. It should be run on a VM and accessible via external IP. The logic should be implemented using Python.
+Receptsamling – Recipe Library on Google Cloud Platform
+=======================================================
+
+This project provides a Python web application for collecting and managing
+recipes. The UI allows you to upload new recipes (including an optional photo)
+and remove existing ones. Recipes are persisted in Google Cloud Firestore and
+any uploaded images are stored in Google Cloud Storage. The intended deployment
+is a Google Compute Engine VM that exposes the Flask application via the
+instance's external IP address.
+
+Features
+--------
+- Upload recipes with a title, description, ingredients, instructions, and an
+  optional image.
+- View all stored recipes in a clean card-based layout.
+- Remove unwanted recipes (also deleting associated Cloud Storage objects).
+- Google Cloud native persistence with Firestore and Cloud Storage.
+
+Architecture
+------------
+- **Flask** serves the UI, request handling, and validation.
+- **Firestore** stores recipe metadata in a collection (defaults to
+  ``recipes``).
+- **Cloud Storage** keeps recipe images in a configured bucket under the
+  ``recipes/`` prefix.
+
+Environment configuration
+-------------------------
+The application relies on the following environment variables:
+
+```
+FLASK_SECRET_KEY    Secret used for Flask session cookies (default: development string).
+GCP_PROJECT         Google Cloud project ID (required for production).
+RECIPES_COLLECTION  Firestore collection name (defaults to "recipes").
+GCS_BUCKET          Cloud Storage bucket used for storing recipe images.
+GOOGLE_APPLICATION_CREDENTIALS  Path to a service account JSON key file with
+                                Firestore and Storage permissions.
+```
+
+Firestore must be running in **Native mode**. Cloud Storage buckets must allow
+the application service account to upload objects and, optionally, invoke
+``make_public()`` if you want public images.
+
+Local development
+-----------------
+1. Create and activate a virtual environment.
+2. Install dependencies:
+   ```
+   pip install -r requirements.txt
+   ```
+3. Export environment variables (use a service account JSON file downloaded
+   from your GCP project).
+4. Start the development server:
+   ```
+   flask --app main run --host=0.0.0.0 --port=8080
+   ```
+
+Running on Compute Engine
+-------------------------
+1. Provision a VM (e.g., Debian/Ubuntu) with access to the required service
+   account.
+2. Install system packages (Python 3.10+, ``pip``).
+3. Clone this repository onto the VM.
+4. Install dependencies with ``pip install -r requirements.txt``.
+5. Export the environment variables listed above (or provide them using
+   ``systemd`` service files).
+6. Start the application using ``gunicorn`` for production:
+   ```
+   gunicorn --bind 0.0.0.0:8080 main:app
+   ```
+7. Configure firewall rules to allow inbound traffic on the chosen port.
+
+Testing
+-------
+Automated tests rely on an in-memory storage backend and do not require Google
+Cloud access:
+```
+pytest
+```
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Flask==2.3.3
+gunicorn==21.2.0
+google-cloud-firestore==2.11.1
+google-cloud-storage==2.13.0
+pytest==7.4.3

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import uuid
+from datetime import datetime
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app import create_app
+from app.models import Recipe
+
+
+class InMemoryRecipeStorage:
+    """Simple storage backend used for tests."""
+
+    def __init__(self) -> None:
+        self._recipes: list[Recipe] = []
+
+    def list_recipes(self):
+        return sorted(
+            self._recipes,
+            key=lambda recipe: recipe.created_at or datetime.min,
+            reverse=True,
+        )
+
+    def add_recipe(
+        self,
+        *,
+        title: str,
+        description: str,
+        ingredients_text: str,
+        instructions: str,
+        image,
+    ) -> Recipe:
+        ingredients = [line.strip() for line in ingredients_text.splitlines() if line.strip()]
+        recipe = Recipe(
+            id=uuid.uuid4().hex,
+            title=title,
+            description=description,
+            ingredients=ingredients,
+            instructions=instructions,
+            image_url=None,
+            created_at=datetime.utcnow(),
+        )
+        self._recipes.append(recipe)
+        return recipe
+
+    def delete_recipe(self, recipe_id: str) -> None:
+        for index, recipe in enumerate(self._recipes):
+            if recipe.id == recipe_id:
+                self._recipes.pop(index)
+                return
+        raise KeyError(recipe_id)
+
+
+def create_test_client():
+    storage = InMemoryRecipeStorage()
+    app = create_app(storage=storage)
+    app.config.update(TESTING=True, WTF_CSRF_ENABLED=False)
+    return app.test_client(), storage
+
+
+def test_index_shows_existing_recipes():
+    client, storage = create_test_client()
+    storage.add_recipe(
+        title="Chocolate Cake",
+        description="Rich and moist.",
+        ingredients_text="flour\nsugar",
+        instructions="Bake it.",
+        image=None,
+    )
+
+    response = client.get("/")
+    assert response.status_code == 200
+    assert b"Chocolate Cake" in response.data
+
+
+def test_can_add_recipe_via_form():
+    client, storage = create_test_client()
+
+    response = client.post(
+        "/recipes",
+        data={
+            "title": "Summer Salad",
+            "description": "Fresh veggies",
+            "ingredients": "tomatoes\ncucumber",
+            "instructions": "Mix everything.",
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    titles = [recipe.title for recipe in storage.list_recipes()]
+    assert "Summer Salad" in titles
+    assert "Recipe &#39;Summer Salad&#39; saved." in response.get_data(as_text=True)
+
+
+def test_cannot_add_recipe_without_title():
+    client, storage = create_test_client()
+
+    response = client.post(
+        "/recipes",
+        data={"title": "", "description": ""},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert not list(storage.list_recipes())
+    assert b"Please provide a recipe title." in response.data
+
+
+def test_delete_recipe_removes_item():
+    client, storage = create_test_client()
+    recipe = storage.add_recipe(
+        title="Tofu Stir Fry",
+        description="Quick weeknight dinner",
+        ingredients_text="tofu",
+        instructions="Cook it.",
+        image=None,
+    )
+
+    response = client.post(f"/recipes/{recipe.id}/delete", follow_redirects=True)
+
+    assert response.status_code == 200
+    assert all(existing.id != recipe.id for existing in storage.list_recipes())
+    assert b"Recipe deleted." in response.data


### PR DESCRIPTION
## Summary
- add a Flask application that exposes recipe listing, upload, and deletion endpoints backed by Firestore/Cloud Storage
- build HTML templates and styling for the recipe form and grid layout
- document deployment steps and add automated tests with an in-memory repository

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c920daad908328bf136446aaad76af