### PR TITLE
Enable editing of saved recipes

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -97,22 +97,39 @@ textarea {
   min-height: 120px;
 }
 
-button {
+button,
+.button-link {
   cursor: pointer;
   border: none;
   padding: 0.75rem 1.5rem;
   border-radius: 999px;
   font-weight: 600;
   font-size: 1rem;
+  display: inline-block;
+  text-decoration: none;
 }
 
-button.primary {
+button.primary,
+.button-link.primary {
   background: var(--accent);
   color: white;
 }
 
-button.primary:hover {
+button.primary:hover,
+.button-link.primary:hover {
   background: var(--accent-dark);
+}
+
+button.secondary,
+.button-link.secondary {
+  background: transparent;
+  color: var(--accent);
+  border: 2px solid var(--accent);
+}
+
+button.secondary:hover,
+.button-link.secondary:hover {
+  background: rgba(37, 99, 235, 0.08);
 }
 
 button.danger {
@@ -171,8 +188,27 @@ button.danger:hover {
   margin-top: 0.35rem;
 }
 
-.recipe-content form {
+.recipe-actions {
   margin-top: auto;
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.recipe-actions form {
+  margin: 0;
+}
+
+.form-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.field-hint {
+  margin-top: 0.35rem;
+  font-size: 0.9rem;
+  color: var(--muted);
 }
 
 .flash-container {

--- a/app/storage.py
+++ b/app/storage.py
@@ -13,6 +13,9 @@ class RecipeRepository(Protocol):
     def list_recipes(self) -> Iterable[Recipe]:
         """Return an iterable of stored recipes ordered newest first."""
 
+    def get_recipe(self, recipe_id: str) -> Recipe:
+        """Return a single recipe or raise :class:`KeyError` if missing."""
+
     def add_recipe(
         self,
         *,
@@ -23,6 +26,18 @@ class RecipeRepository(Protocol):
         image: FileStorage | None,
     ) -> Recipe:
         """Persist a new recipe and return the stored instance."""
+
+    def update_recipe(
+        self,
+        recipe_id: str,
+        *,
+        title: str,
+        description: str,
+        ingredients_text: str,
+        instructions: str,
+        image: FileStorage | None,
+    ) -> Recipe:
+        """Update an existing recipe and return the new representation."""
 
     def delete_recipe(self, recipe_id: str) -> None:
         """Remove a recipe and any associated assets."""

--- a/app/templates/edit_recipe.html
+++ b/app/templates/edit_recipe.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="form-section">
+  <h2>Edit recipe</h2>
+  <form action="{{ url_for('update_recipe', recipe_id=recipe.id) }}" method="post" enctype="multipart/form-data">
+    <div class="form-grid">
+      <label>
+        <span>Recipe title *</span>
+        <input type="text" name="title" value="{{ recipe.title }}" required />
+      </label>
+      <label>
+        <span>Short description</span>
+        <input type="text" name="description" value="{{ recipe.description }}" />
+      </label>
+      <label class="full-width">
+        <span>Ingredients (one per line)</span>
+        <textarea name="ingredients" rows="4">{{ ingredients_text }}</textarea>
+      </label>
+      <label class="full-width">
+        <span>Instructions</span>
+        <textarea name="instructions" rows="6">{{ recipe.instructions }}</textarea>
+      </label>
+      <label>
+        <span>Optional new image</span>
+        <input type="file" name="image" accept="image/png,image/jpeg,image/gif,image/webp" />
+        <p class="field-hint">Leave empty to keep the current image.</p>
+      </label>
+    </div>
+    <div class="form-actions">
+      <button type="submit" class="primary">Update recipe</button>
+      <a href="{{ url_for('index') }}" class="button-link secondary">Cancel</a>
+    </div>
+  </form>
+</section>
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -64,9 +64,14 @@
         <h4>Instructions</h4>
         <p class="instructions">{{ recipe.instructions }}</p>
         {% endif %}
-        <form action="{{ url_for('delete_recipe', recipe_id=recipe.id) }}" method="post">
-          <button type="submit" class="danger">Delete</button>
-        </form>
+        <div class="recipe-actions">
+          <form action="{{ url_for('edit_recipe', recipe_id=recipe.id) }}" method="get">
+            <button type="submit" class="secondary">Edit</button>
+          </form>
+          <form action="{{ url_for('delete_recipe', recipe_id=recipe.id) }}" method="post">
+            <button type="submit" class="danger">Delete</button>
+          </form>
+        </div>
       </div>
     </article>
     {% endfor %}


### PR DESCRIPTION
## Summary
- add routes and templates that let users edit existing recipes via a dedicated form
- expand the recipe storage protocol and Firestore implementation to support retrieving and updating recipes, including image changes
- refresh the UI and tests to cover the new editing workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c942ec95648328a4ff5702b57ff53f