### PR TITLE
Refine recipe overview layout

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -53,8 +53,7 @@ main {
   color: var(--muted);
 }
 
-.form-section,
-.recipes-section {
+.form-section {
   background: var(--card-bg);
   border-radius: 16px;
   padding: 2rem;
@@ -62,8 +61,7 @@ main {
   box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
 }
 
-.form-section h2,
-.recipes-section h2 {
+.form-section h2 {
   margin-top: 0;
 }
 
@@ -141,61 +139,160 @@ button.danger:hover {
   background: var(--danger-dark);
 }
 
-.recipes-grid {
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.recipes-layout {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: minmax(240px, 280px) 1fr;
+  gap: 1.5rem;
+  align-items: start;
+  margin-bottom: 2rem;
+}
+
+.recipe-list-panel,
+.recipe-detail-panel {
+  background: var(--card-bg);
+  border-radius: 16px;
+  padding: 1.75rem;
+  border: 1px solid var(--border);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+}
+
+.recipe-list-panel {
+  display: flex;
+  flex-direction: column;
   gap: 1.5rem;
 }
 
-.recipe-card {
-  border: 1px solid var(--border);
-  border-radius: 18px;
-  overflow: hidden;
-  background: var(--card-bg);
+.panel-header {
   display: flex;
   flex-direction: column;
-  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.06);
+  gap: 0.35rem;
 }
 
-.recipe-card img {
-  width: 100%;
-  height: 200px;
-  object-fit: cover;
+.panel-header h2 {
+  margin: 0;
 }
 
-.recipe-content {
-  padding: 1.25rem 1.5rem 1.5rem;
-  display: flex;
-  flex-direction: column;
+.panel-subtitle {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.recipe-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
   gap: 0.75rem;
 }
 
-.recipe-content h3 {
-  margin: 0;
+.recipe-list-item {
+  display: block;
 }
 
-.recipe-content .description {
+.recipe-list-link {
+  display: block;
+  padding: 0.9rem 1rem;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  background: rgba(148, 163, 184, 0.12);
+  color: inherit;
+  text-decoration: none;
+  transition: border-color 0.2s ease, background-color 0.2s ease, transform 0.2s ease;
+}
+
+.recipe-list-link:hover {
+  border-color: var(--accent);
+  transform: translateY(-1px);
+}
+
+.recipe-list-item.active .recipe-list-link {
+  border-color: var(--accent);
+  background: rgba(37, 99, 235, 0.14);
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.18);
+}
+
+.recipe-list-title {
+  display: block;
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.recipe-list-description {
+  display: block;
   color: var(--muted);
-  margin: 0;
+  font-size: 0.92rem;
+  margin-top: 0.25rem;
 }
 
-.recipe-content ul {
+.recipe-detail-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-height: 320px;
+}
+
+.recipe-detail-image {
+  width: 100%;
+  max-height: 260px;
+  object-fit: cover;
+  border-radius: 14px;
+}
+
+.recipe-detail-title {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.recipe-detail-description {
+  margin: 0;
+  color: var(--muted);
+  font-size: 1rem;
+}
+
+.recipe-detail-ingredients {
   margin: 0;
   padding-left: 1.25rem;
 }
 
-.recipe-content ul li + li {
+.recipe-detail-ingredients li + li {
   margin-top: 0.35rem;
 }
 
-.recipe-actions {
-  margin-top: auto;
-  display: flex;
-  gap: 0.75rem;
-  flex-wrap: wrap;
+.recipe-detail-instructions {
+  margin: 0;
+  white-space: pre-line;
+  line-height: 1.65;
 }
 
-.recipe-actions form {
+.recipe-detail-placeholder {
+  margin: 0;
+  color: var(--muted);
+  font-style: italic;
+}
+
+.recipe-actions-bar {
+  background: var(--card-bg);
+  border-radius: 16px;
+  padding: 1.25rem 1.75rem;
+  border: 1px solid var(--border);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-start;
+}
+
+.recipe-actions-bar form {
+  margin: 0;
+}
+
+.recipe-actions-bar button {
   margin: 0;
 }
 
@@ -238,9 +335,27 @@ button.danger:hover {
   font-style: italic;
 }
 
+@media (max-width: 960px) {
+  .recipes-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 640px) {
   .form-section,
-  .recipes-section {
+  .recipe-list-panel,
+  .recipe-detail-panel,
+  .recipe-actions-bar {
     padding: 1.5rem;
+  }
+
+  .recipe-actions-bar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .recipe-actions-bar form,
+  .recipe-actions-bar button {
+    width: 100%;
   }
 }

--- a/app/templates/add_recipe.html
+++ b/app/templates/add_recipe.html
@@ -1,0 +1,43 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="form-section">
+  <h2>Add a new recipe</h2>
+  <form action="{{ url_for('create_recipe') }}" method="post" enctype="multipart/form-data">
+    <div class="form-grid">
+      <label>
+        <span>Recipe title *</span>
+        <input type="text" name="title" placeholder="Grandma's apple pie" required />
+      </label>
+      <label>
+        <span>Short description</span>
+        <input type="text" name="description" placeholder="Why this recipe is special" />
+      </label>
+      <label class="full-width">
+        <span>Ingredients (one per line)</span>
+        <textarea
+          name="ingredients"
+          rows="4"
+          placeholder="2 cups flour&#10;1 tsp cinnamon"
+        ></textarea>
+      </label>
+      <label class="full-width">
+        <span>Instructions</span>
+        <textarea
+          name="instructions"
+          rows="6"
+          placeholder="Describe how to make the recipe"
+        ></textarea>
+      </label>
+      <label>
+        <span>Optional image</span>
+        <input type="file" name="image" accept="image/png,image/jpeg,image/gif,image/webp" />
+      </label>
+    </div>
+    <div class="form-actions">
+      <button type="submit" class="primary">Save recipe</button>
+      <a href="{{ url_for('index') }}" class="button-link secondary">Cancel</a>
+    </div>
+  </form>
+</section>
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,83 +1,76 @@
 {% extends "base.html" %}
 
 {% block content %}
-<section class="form-section">
-  <h2>Add a new recipe</h2>
-  <form action="{{ url_for('create_recipe') }}" method="post" enctype="multipart/form-data">
-    <div class="form-grid">
-      <label>
-        <span>Recipe title *</span>
-        <input type="text" name="title" placeholder="Grandma's apple pie" required />
-      </label>
-      <label>
-        <span>Short description</span>
-        <input type="text" name="description" placeholder="Why this recipe is special" />
-      </label>
-      <label class="full-width">
-        <span>Ingredients (one per line)</span>
-        <textarea
-          name="ingredients"
-          rows="4"
-          placeholder="2 cups flour&#10;1 tsp cinnamon"
-        ></textarea>
-      </label>
-      <label class="full-width">
-        <span>Instructions</span>
-        <textarea
-          name="instructions"
-          rows="6"
-          placeholder="Describe how to make the recipe"
-        ></textarea>
-      </label>
-      <label>
-        <span>Optional image</span>
-        <input type="file" name="image" accept="image/png,image/jpeg,image/gif,image/webp" />
-      </label>
+<div class="recipes-layout">
+  <section class="recipe-list-panel">
+    <div class="panel-header">
+      <h2>Saved recipes</h2>
+      <p class="panel-subtitle">Select a recipe to see its full details.</p>
     </div>
-    <button type="submit" class="primary">Save recipe</button>
-  </form>
-</section>
+    {% if recipes %}
+    <ul class="recipe-list">
+      {% for recipe in recipes %}
+      <li class="recipe-list-item{% if recipe.id == selected_id %} active{% endif %}">
+        <a href="{{ url_for('index', selected=recipe.id) }}" class="recipe-list-link">
+          <span class="recipe-list-title">{{ recipe.title }}</span>
+          {% if recipe.description %}
+          <span class="recipe-list-description">{{ recipe.description }}</span>
+          {% endif %}
+        </a>
+      </li>
+      {% endfor %}
+    </ul>
+    {% else %}
+    <p class="empty-state">No recipes saved yet. Add one to get started.</p>
+    {% endif %}
+  </section>
+  <section class="recipe-detail-panel">
+    {% if selected_recipe %}
+    {% if selected_recipe.image_url %}
+    <img
+      src="{{ selected_recipe.image_url }}"
+      alt="{{ selected_recipe.title }}"
+      class="recipe-detail-image"
+    />
+    {% endif %}
+    <h2 class="recipe-detail-title">{{ selected_recipe.title }}</h2>
+    {% if selected_recipe.description %}
+    <p class="recipe-detail-description">{{ selected_recipe.description }}</p>
+    {% endif %}
+    {% if selected_recipe.ingredients %}
+    <h3>Ingredients</h3>
+    <ul class="recipe-detail-ingredients">
+      {% for ingredient in selected_recipe.ingredients %}
+      <li>{{ ingredient }}</li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+    {% if selected_recipe.instructions %}
+    <h3>Instructions</h3>
+    <p class="recipe-detail-instructions">{{ selected_recipe.instructions }}</p>
+    {% endif %}
+    {% elif recipes %}
+    <p class="recipe-detail-placeholder">Select a recipe from the list to view its details.</p>
+    {% else %}
+    <p class="recipe-detail-placeholder">Add your first recipe to see it here.</p>
+    {% endif %}
+  </section>
+</div>
 
-<section class="recipes-section">
-  <h2>Saved recipes</h2>
-  {% if recipes %}
-  <div class="recipes-grid">
-    {% for recipe in recipes %}
-    <article class="recipe-card">
-      {% if recipe.image_url %}
-      <img src="{{ recipe.image_url }}" alt="{{ recipe.title }}" />
-      {% endif %}
-      <div class="recipe-content">
-        <h3>{{ recipe.title }}</h3>
-        {% if recipe.description %}
-        <p class="description">{{ recipe.description }}</p>
-        {% endif %}
-        {% if recipe.ingredients %}
-        <h4>Ingredients</h4>
-        <ul>
-          {% for ingredient in recipe.ingredients %}
-          <li>{{ ingredient }}</li>
-          {% endfor %}
-        </ul>
-        {% endif %}
-        {% if recipe.instructions %}
-        <h4>Instructions</h4>
-        <p class="instructions">{{ recipe.instructions }}</p>
-        {% endif %}
-        <div class="recipe-actions">
-          <form action="{{ url_for('edit_recipe', recipe_id=recipe.id) }}" method="get">
-            <button type="submit" class="secondary">Edit</button>
-          </form>
-          <form action="{{ url_for('delete_recipe', recipe_id=recipe.id) }}" method="post">
-            <button type="submit" class="danger">Delete</button>
-          </form>
-        </div>
-      </div>
-    </article>
-    {% endfor %}
-  </div>
+<div class="recipe-actions-bar">
+  <form action="{{ url_for('new_recipe') }}" method="get">
+    <button type="submit" class="primary">Add recipe</button>
+  </form>
+  {% if selected_recipe %}
+  <form action="{{ url_for('edit_recipe', recipe_id=selected_recipe.id) }}" method="get">
+    <button type="submit" class="secondary">Edit selected</button>
+  </form>
+  <form action="{{ url_for('delete_recipe', recipe_id=selected_recipe.id) }}" method="post">
+    <button type="submit" class="danger">Delete selected</button>
+  </form>
   {% else %}
-  <p class="empty-state">No recipes saved yet. Start by adding one above.</p>
+  <button type="button" class="secondary" disabled>Edit selected</button>
+  <button type="button" class="danger" disabled>Delete selected</button>
   {% endif %}
-</section>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- restructure the home view to show a selectable recipe list alongside the details of the active recipe and contextual actions
- add a dedicated page for creating new recipes while keeping success redirects focused on the chosen item
- refresh the stylesheet to support the split layout, detail panel, and responsive button bar

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c947b20e0c8328979decc7567ed04d