### PR TITLE
Use gunicorn as the container entrypoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,14 @@
+"""WSGI entrypoint for the Receptsamling application.
+
+The Flask development server is intentionally not started from this module so
+that containerized deployments rely on Gunicorn (see ``Dockerfile``). Local
+development can still use ``flask --app main run`` which imports the ``app``
+object defined below.
+"""
+
 from app import create_app
 
 app = create_app()
 
 
-if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=8080, debug=False)
+__all__ = ["app"]

--- a/readme.txt
+++ b/readme.txt
@@ -56,6 +56,9 @@ Local development
    flask --app main run --host=0.0.0.0 --port=8080
    ```
 
+   Containers should instead rely on Gunicorn which is configured in the
+   provided ``Dockerfile``.
+
 Running on Compute Engine
 -------------------------
 1. Provision a VM (e.g., Debian/Ubuntu) with access to the required service


### PR DESCRIPTION
## Summary
- expose the Flask application purely as a WSGI object so containers rely on Gunicorn
- document that containers should use the Gunicorn configuration shipped with the project

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbfe6749208328887210e2f3ee4bee