### PR TITLE
Avoid ACL changes when generating fallback image URLs

### DIFF
--- a/app/gcp_storage.py
+++ b/app/gcp_storage.py
@@ -242,7 +242,11 @@ class FirestoreRecipeStorage(RecipeRepository):
                 version="v4", method="GET", expiration=SIGNED_URL_EXPIRATION
             )
         except (ValueError, TypeError, AttributeError, auth_exceptions.GoogleAuthError):
-            blob.make_public()
+            # Signed URLs require credentials capable of signing requests. In
+            # development environments that lack such credentials we fall back
+            # to the object's public URL. Buckets that use uniform
+            # bucket-level access cannot use legacy ACLs (``make_public``), so
+            # we simply return the public URL without modifying permissions.
             return blob.public_url
 
 


### PR DESCRIPTION
## Summary
- stop invoking Cloud Storage ACL updates when generating fallback image URLs
- return the object's public URL as a non-ACL fallback so uploads succeed on uniform bucket-level access buckets

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4f5b38cdc8328bdc54ec98742d13e